### PR TITLE
do not resend logs that cause exceptions

### DIFF
--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -411,6 +411,25 @@ namespace AWS.Logger.Core
             }
         }
 
+        private void PrepareLogEventBatchForSending()
+        {
+            //Make sure the log events are in the right order.
+            _repo._request.LogEvents.Sort((ev1, ev2) => ev1.Timestamp.CompareTo(ev2.Timestamp));
+            if (_repo._request.LogEvents.Count > 0)
+            {
+                DateTime latestLogDateTime = _repo._request.LogEvents.Last().Timestamp;
+
+                //avoid the error that the log events should be in a 24 hours range
+                //https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/logs/client/put_log_events.html#put-log-events
+                while (_repo._request.LogEvents.Count > 0 &&
+                    (latestLogDateTime - _repo._request.LogEvents.First().Timestamp > TimeSpan.FromHours(24))
+                    )
+                {
+                    _repo.RemoveMessageAt(0);
+                }
+            }
+        }
+
         /// <summary>
         /// Method to transmit the PutLogEvent Request
         /// </summary>
@@ -420,8 +439,7 @@ namespace AWS.Logger.Core
         {
             try
             {
-                //Make sure the log events are in the right order.
-                _repo._request.LogEvents.Sort((ev1, ev2) => ev1.Timestamp.CompareTo(ev2.Timestamp));
+                PrepareLogEventBatchForSending();
                 var response = await _client.PutLogEventsAsync(_repo._request, token).ConfigureAwait(false);
                 _repo.Reset(response.NextSequenceToken);
                 _requestCount = 5;
@@ -632,6 +650,18 @@ namespace AWS.Logger.Core
                 Encoding unicode = Encoding.Unicode;
                 _totalMessageSize += unicode.GetMaxByteCount(ev.Message.Length);
                 _request.LogEvents.Add(ev);
+            }
+
+            public void RemoveMessageAt(int index)
+            {
+                if (index < 0 || index >= _request.LogEvents.Count)
+                {
+                    return;
+                }
+                Encoding unicode = Encoding.Unicode;
+                InputLogEvent ev = _request.LogEvents[index];
+                _totalMessageSize -= unicode.GetMaxByteCount(ev.Message.Length);
+                _request.LogEvents.RemoveAt(index);
             }
 
             public void Reset(string SeqToken)

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -23,9 +23,6 @@ namespace AWS.Logger.Core
     /// </summary>
     public class AWSLoggerCore : IAWSLoggerCore
     {
-        private const string MSG_PREFIX = "JamesVerAWSLogger: ";
-        private static TimeSpan s_LogTimestampOffset = TimeSpan.Zero;
-
         const int MAX_MESSAGE_SIZE_IN_BYTES = 256000;
 
         #region Private Members
@@ -243,7 +240,6 @@ namespace AWS.Logger.Core
 
         private void AddSingleMessage(string message)
         {
-            message = MSG_PREFIX + message;
             if (_pendingMessageQueue.Count > _config.MaxQueuedMessages)
             {
                 if (_maxBufferTimeStamp.AddMinutes(MAX_BUFFER_TIMEDIFF) < DateTime.UtcNow)
@@ -256,7 +252,7 @@ namespace AWS.Logger.Core
                     _maxBufferTimeStamp = DateTime.UtcNow;
                     _pendingMessageQueue.Enqueue(new InputLogEvent
                     {
-                        Timestamp = DateTime.UtcNow + s_LogTimestampOffset,
+                        Timestamp = DateTime.UtcNow,
                         Message = message,
                     });
                 }
@@ -265,7 +261,7 @@ namespace AWS.Logger.Core
             {
                 _pendingMessageQueue.Enqueue(new InputLogEvent
                 {
-                    Timestamp = DateTime.UtcNow + s_LogTimestampOffset,
+                    Timestamp = DateTime.UtcNow,
                     Message = message,
                 });
             }

--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -396,13 +396,11 @@ namespace AWS.Logger.Core
                 }
                 catch (Exception ex)
                 {
-                    // We don't want to kill the main monitor loop. We will simply log the error, then continue.
-                    // If it is an OperationCancelledException, die
-                    LogLibraryServiceError(ex);
-
                     //drop logs in sending batch since those logs may cause exceptions
                     _repo.Reset(null);
-                    LogLibraryServiceError(new Exception("Logs in sending batch are dropped because of exceptions"));
+                    // We don't want to kill the main monitor loop. We will simply log the error, then continue.
+                    // If it is an OperationCancelledException, die
+                    LogLibraryServiceError(new Exception("Logs in the sending batch are dropped because of exceptions", ex));
                 }
             }
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. drop logs that cause exceptions when sending to the server
2. remove logs older than 24 hours compared to the newest log 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
