### PR TITLE
set auth region when service url is used

### DIFF
--- a/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
+++ b/src/AWS.Logger.Core/Core/AWSLoggerCore.cs
@@ -92,6 +92,7 @@ namespace AWS.Logger.Core
                 {
                     awsConfig.UseHttp = true;
                 }
+                awsConfig.AuthenticationRegion = _config.Region;
             }
             else
             {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
set `AmazonCloudWatchLogsConfig.AuthenticationRegion` by `AWSLoggerConfig.Region` (will be copied from `AWSTarget`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
